### PR TITLE
Upgrading the Flink version to 1.17.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 * Added the `build.sh`
 * Updated the `.gitignore`
 * Added a pull request template for Github.
+
+## Version 1.1.1
+
+* Upgrade to Flink 1.17.1

--- a/install_flink.sh
+++ b/install_flink.sh
@@ -1,2 +1,2 @@
-curl https://dlcdn.apache.org/flink/flink-1.17.0/flink-1.17.0-bin-scala_2.12.tgz --output flink-1.17.0.tgz
+curl https://archive.apache.org/dist/flink/flink-1.17.1/flink-1.17.1-bin-scala_2.12.tgz --output flink-1.17.1.tgz
 tar -xzf flink-*.tgz


### PR DESCRIPTION
## Description

Upgrading to Flink 1.17.1 and changing to a more stable download location.

## Checklist

- [x] Unit tests created/updated for any new code (where applicable).
- [x] Run all tests with `./build.sh validate`.
- [x] Update the [CHANGELOG.md](CHANGELOG.md).
- [x] Update the [README.md](README.md) if necessary.